### PR TITLE
Scaffold monorepo with mock UI and API skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+LIFF_ID=your-liff-id
+APP_JWT_SECRET=replace-with-random-secret
+LINE_CHANNEL_ID=your-line-channel-id
+LINE_CHANNEL_SECRET=your-line-channel-secret
+LINE_MESSAGING_CHANNEL_ACCESS_TOKEN=your-line-messaging-access-token

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Node / Next.js
+node_modules/
+.next/
+out/
+
+# Java / Gradle
+api/build/
+api/.gradle/
+
+# Env & misc
+.env
+*.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+## Anshin Dana
+
+Monorepo for a LINE LIFF-based household stock management assistant. This repository houses:
+
+- **web/**: Next.js client optimized for LIFF with barcode scan-driven flows.
+- **api/**: Spring Boot service for authentication, stock management, and scheduled notifications (worker profile).
+- **infra/**: Development-time infrastructure (nginx reverse proxy, docker compose scaffolding).
+- **docs/**: Architecture, API, and schema references.
+
+### Getting started (development)
+
+1. Copy `.env.example` to `.env` and fill required secrets (LINE channel credentials, JWT secret, etc.).
+2. Build and start with Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+The reverse proxy exposes:
+
+- Next.js web at `http://localhost:8080`
+- API proxied at `http://localhost:8080/api`
+
+### Project goals
+
+- Frictionless registration and daily-use flows (scan → suggest → minimal input).
+- FEFO consumption (earliest expiry first).
+- Digest-style LINE notifications to avoid noise.
+
+See `docs/architecture.md` for more context.

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.3.1'
+    id 'io.spring.dependency-management' version '1.1.5'
+}
+
+group = 'com.anshindana'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '21'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.40.0'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/api/settings.gradle
+++ b/api/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'anshin-dana-api'

--- a/api/src/main/java/com/anshindana/ApiApplication.java
+++ b/api/src/main/java/com/anshindana/ApiApplication.java
@@ -1,0 +1,14 @@
+package com.anshindana;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+public class ApiApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ApiApplication.class, args);
+    }
+}

--- a/api/src/main/java/com/anshindana/config/SecurityConfig.java
+++ b/api/src/main/java/com/anshindana/config/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.anshindana.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .cors(Customizer.withDefaults())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+}

--- a/api/src/main/java/com/anshindana/controller/AuthController.java
+++ b/api/src/main/java/com/anshindana/controller/AuthController.java
@@ -1,0 +1,29 @@
+package com.anshindana.controller;
+
+import com.anshindana.service.AuthService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/line")
+    public ResponseEntity<AuthService.AuthResponse> exchange(@Valid @RequestBody LineAuthRequest request) {
+        return ResponseEntity.ok(authService.exchangeLineIdToken(request.idToken()));
+    }
+
+    public record LineAuthRequest(@NotBlank String idToken) {
+    }
+}

--- a/api/src/main/java/com/anshindana/controller/ConsumeController.java
+++ b/api/src/main/java/com/anshindana/controller/ConsumeController.java
@@ -1,0 +1,30 @@
+package com.anshindana.controller;
+
+import com.anshindana.service.StockService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/consume")
+public class ConsumeController {
+
+    private final StockService stockService;
+
+    public ConsumeController(StockService stockService) {
+        this.stockService = stockService;
+    }
+
+    @PostMapping
+    public ResponseEntity<StockService.ConsumptionResult> consume(@Valid @RequestBody ConsumeRequest request) {
+        return ResponseEntity.ok(stockService.consume(request.stockItemId(), request.quantity()));
+    }
+
+    public record ConsumeRequest(@NotNull Long stockItemId, @Positive int quantity) {
+    }
+}

--- a/api/src/main/java/com/anshindana/controller/PlanController.java
+++ b/api/src/main/java/com/anshindana/controller/PlanController.java
@@ -1,0 +1,25 @@
+package com.anshindana.controller;
+
+import com.anshindana.service.TaskService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/plan")
+public class PlanController {
+
+    private final TaskService taskService;
+
+    public PlanController(TaskService taskService) {
+        this.taskService = taskService;
+    }
+
+    @GetMapping("/emergency")
+    public ResponseEntity<Object> emergency(@RequestParam(defaultValue = "4") int people,
+                                            @RequestParam(defaultValue = "3") int days) {
+        return ResponseEntity.ok(taskService.emergencyPlan(people, days));
+    }
+}

--- a/api/src/main/java/com/anshindana/controller/ScanController.java
+++ b/api/src/main/java/com/anshindana/controller/ScanController.java
@@ -1,0 +1,36 @@
+package com.anshindana.controller;
+
+import com.anshindana.domain.ProductCandidate;
+import com.anshindana.service.StockService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/scan")
+public class ScanController {
+
+    private final StockService stockService;
+
+    public ScanController(StockService stockService) {
+        this.stockService = stockService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Map<String, Object>> scan(@Valid @RequestBody ScanRequest request) {
+        ProductCandidate candidate = stockService.findProductByBarcode(request.barcode());
+        return ResponseEntity.ok(Map.of(
+                "productCandidate", candidate,
+                "lastUsedExpiryTemplates", stockService.lastUsedExpiryTemplates(1L, request.barcode())
+        ));
+    }
+
+    public record ScanRequest(@NotBlank String barcode) {
+    }
+}

--- a/api/src/main/java/com/anshindana/controller/StockController.java
+++ b/api/src/main/java/com/anshindana/controller/StockController.java
@@ -1,0 +1,57 @@
+package com.anshindana.controller;
+
+import com.anshindana.domain.StockItem;
+import com.anshindana.service.StockService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/stocks")
+public class StockController {
+
+    private final StockService stockService;
+
+    public StockController(StockService stockService) {
+        this.stockService = stockService;
+    }
+
+    @PostMapping
+    public ResponseEntity<StockItem> register(@Valid @RequestBody RegisterStockRequest request) {
+        StockItem item = stockService.registerStock(
+                request.name(),
+                request.category(),
+                request.quantity(),
+                request.unit(),
+                request.expiresOn()
+        );
+        return ResponseEntity.ok(item);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<StockItem>> list(@RequestParam(defaultValue = "expiresSoon") String sort) {
+        return ResponseEntity.ok(stockService.listStocks());
+    }
+
+    public record RegisterStockRequest(
+            String barcode,
+            @NotBlank String name,
+            @NotBlank String category,
+            @Positive int quantity,
+            @NotBlank String unit,
+            @NotNull @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate expiresOn
+    ) {
+    }
+}

--- a/api/src/main/java/com/anshindana/controller/TaskController.java
+++ b/api/src/main/java/com/anshindana/controller/TaskController.java
@@ -1,0 +1,24 @@
+package com.anshindana.controller;
+
+import com.anshindana.domain.TodayTasks;
+import com.anshindana.service.TaskService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/tasks")
+public class TaskController {
+
+    private final TaskService taskService;
+
+    public TaskController(TaskService taskService) {
+        this.taskService = taskService;
+    }
+
+    @GetMapping("/today")
+    public ResponseEntity<TodayTasks> today() {
+        return ResponseEntity.ok(taskService.getTodayTasks(1L));
+    }
+}

--- a/api/src/main/java/com/anshindana/domain/ProductCandidate.java
+++ b/api/src/main/java/com/anshindana/domain/ProductCandidate.java
@@ -1,0 +1,4 @@
+package com.anshindana.domain;
+
+public record ProductCandidate(String barcode, String name, String brand, String category) {
+}

--- a/api/src/main/java/com/anshindana/domain/StockItem.java
+++ b/api/src/main/java/com/anshindana/domain/StockItem.java
@@ -1,0 +1,4 @@
+package com.anshindana.domain;
+
+public record StockItem(Long id, String name, String category, String unit, int totalQuantity, StockLot nextLot) {
+}

--- a/api/src/main/java/com/anshindana/domain/StockLot.java
+++ b/api/src/main/java/com/anshindana/domain/StockLot.java
@@ -1,0 +1,6 @@
+package com.anshindana.domain;
+
+import java.time.LocalDate;
+
+public record StockLot(Long id, LocalDate expiresOn, int quantity, LocalDate purchasedOn) {
+}

--- a/api/src/main/java/com/anshindana/domain/TodayTasks.java
+++ b/api/src/main/java/com/anshindana/domain/TodayTasks.java
@@ -1,0 +1,22 @@
+package com.anshindana.domain;
+
+import java.util.List;
+
+public record TodayTasks(
+        List<ExpiringItem> expiringSoon,
+        List<ExpiredItem> expired,
+        List<LowStockItem> lowStock,
+        List<SuggestedConsume> suggestedConsume
+) {
+    public record ExpiringItem(String name, String expiresOn) {
+    }
+
+    public record ExpiredItem(String name, String expiredOn) {
+    }
+
+    public record LowStockItem(String category, String suggestion) {
+    }
+
+    public record SuggestedConsume(String name, String reason) {
+    }
+}

--- a/api/src/main/java/com/anshindana/domain/UserProfile.java
+++ b/api/src/main/java/com/anshindana/domain/UserProfile.java
@@ -1,0 +1,4 @@
+package com.anshindana.domain;
+
+public record UserProfile(Long id, String displayName, String pictureUrl) {
+}

--- a/api/src/main/java/com/anshindana/service/AuthService.java
+++ b/api/src/main/java/com/anshindana/service/AuthService.java
@@ -1,0 +1,40 @@
+package com.anshindana.service;
+
+import com.anshindana.domain.UserProfile;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+
+@Service
+public class AuthService {
+
+    private final SecretKey key;
+
+    public AuthService(@Value("${app.jwt.secret}") String secret) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public AuthResponse exchangeLineIdToken(String idToken) {
+        // NOTE: Mock implementation. In production, verify the LINE ID token via JWKS.
+        UserProfile profile = new UserProfile(1L, "Mock User", "https://example.com/avatar.png");
+        String token = Jwts.builder()
+                .subject(profile.id().toString())
+                .issuer("anshin-dana")
+                .issuedAt(java.util.Date.from(Instant.now()))
+                .expiration(java.util.Date.from(Instant.now().plus(7, ChronoUnit.DAYS)))
+                .claims(Map.of("displayName", profile.displayName()))
+                .signWith(key)
+                .compact();
+        return new AuthResponse(token, profile);
+    }
+
+    public record AuthResponse(String token, UserProfile user) {
+    }
+}

--- a/api/src/main/java/com/anshindana/service/StockService.java
+++ b/api/src/main/java/com/anshindana/service/StockService.java
@@ -1,0 +1,44 @@
+package com.anshindana.service;
+
+import com.anshindana.domain.ProductCandidate;
+import com.anshindana.domain.StockItem;
+import com.anshindana.domain.StockLot;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class StockService {
+
+    public ProductCandidate findProductByBarcode(String barcode) {
+        return new ProductCandidate(barcode, "Mock Beans", "Sample Brand", "canned");
+    }
+
+    public List<String> lastUsedExpiryTemplates(Long userId, String barcode) {
+        return List.of("2025-06-01", "2025-12-01");
+    }
+
+    public StockItem registerStock(String name, String category, int quantity, String unit, LocalDate expiresOn) {
+        StockLot lot = new StockLot(10L, expiresOn, quantity, LocalDate.now());
+        return new StockItem(5L, name, category, unit, quantity, lot);
+    }
+
+    public List<StockItem> listStocks() {
+        return List.of(
+                new StockItem(1L, "パスタソース", "sauce", "袋", 5, new StockLot(1L, LocalDate.now().plusDays(30), 2, LocalDate.now().minusDays(3))),
+                new StockItem(2L, "ツナ缶", "canned", "缶", 8, new StockLot(2L, LocalDate.now().plusDays(40), 3, LocalDate.now().minusDays(10)))
+        );
+    }
+
+    public ConsumptionResult consume(Long stockItemId, int quantity) {
+        List<StockLot> consumed = List.of(
+                new StockLot(1L, LocalDate.now().plusDays(10), 1, LocalDate.now().minusDays(15)),
+                new StockLot(2L, LocalDate.now().plusDays(30), quantity - 1, LocalDate.now().minusDays(20))
+        );
+        return new ConsumptionResult(consumed, 3);
+    }
+
+    public record ConsumptionResult(List<StockLot> consumedLots, int remainingTotal) {
+    }
+}

--- a/api/src/main/java/com/anshindana/service/TaskService.java
+++ b/api/src/main/java/com/anshindana/service/TaskService.java
@@ -1,0 +1,41 @@
+package com.anshindana.service;
+
+import com.anshindana.domain.TodayTasks;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class TaskService {
+
+    public TodayTasks getTodayTasks(Long userId) {
+        return new TodayTasks(
+                List.of(
+                        new TodayTasks.ExpiringItem("パスタソース", "2024-08-03"),
+                        new TodayTasks.ExpiringItem("ツナ缶", "2024-08-10")
+                ),
+                List.of(
+                        new TodayTasks.ExpiredItem("トマトジュース", "2024-07-01")
+                ),
+                List.of(
+                        new TodayTasks.LowStockItem("主食", "お米を2kg買い足し")
+                ),
+                List.of(
+                        new TodayTasks.SuggestedConsume("冷凍唐揚げ", "冷凍庫スペース確保"),
+                        new TodayTasks.SuggestedConsume("パスタ", "賞味期限が近い")
+                )
+        );
+    }
+
+    public Map<String, Object> emergencyPlan(int people, int days) {
+        return Map.of(
+                "people", people,
+                "days", days,
+                "plan", List.of(
+                        Map.of("day", 1, "items", List.of("缶詰セット", "水2L/人")),
+                        Map.of("day", 2, "items", List.of("レトルト米", "味噌汁パック"))
+                )
+        );
+    }
+}

--- a/api/src/main/java/com/anshindana/service/scheduler/NotificationScheduler.java
+++ b/api/src/main/java/com/anshindana/service/scheduler/NotificationScheduler.java
@@ -1,0 +1,19 @@
+package com.anshindana.service.scheduler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("worker")
+public class NotificationScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(NotificationScheduler.class);
+
+    @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Tokyo")
+    public void sendDigest() {
+        log.info("Mock digest notification dispatch (worker profile).");
+    }
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,0 +1,29 @@
+spring:
+  application:
+    name: anshin-dana-api
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+  datasource:
+    url: ${DATABASE_URL:jdbc:postgresql://localhost:5432/anshindana}
+    username: ${DATABASE_USER:app}
+    password: ${DATABASE_PASSWORD:app}
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}
+
+app:
+  jwt:
+    secret: ${APP_JWT_SECRET:dev-secret}
+  line:
+    channel-id: ${LINE_CHANNEL_ID:dummy}
+    channel-secret: ${LINE_CHANNEL_SECRET:dummy}
+    jwks-uri: https://api.line.me/oauth2/v2.1/certs
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+app:
+  mock:
+    enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+version: "3.9"
+services:
+  reverse-proxy:
+    image: nginx:1.27
+    ports:
+      - "8080:80"
+    volumes:
+      - ./infra/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - web
+      - api
+
+  web:
+    build: ./web
+    environment:
+      - NEXT_PUBLIC_LIFF_ID=${LIFF_ID}
+      - NEXT_PUBLIC_API_BASE=/api
+      - TZ=Asia/Tokyo
+    depends_on:
+      - api
+
+  api:
+    build: ./api
+    environment:
+      - SPRING_PROFILES_ACTIVE=dev
+      - TZ=Asia/Tokyo
+      - DATABASE_URL=jdbc:postgresql://db:5432/anshindana
+      - DATABASE_USER=app
+      - DATABASE_PASSWORD=app
+      - APP_JWT_SECRET=${APP_JWT_SECRET}
+      - LINE_CHANNEL_ID=${LINE_CHANNEL_ID}
+      - LINE_CHANNEL_SECRET=${LINE_CHANNEL_SECRET}
+      - LINE_MESSAGING_CHANNEL_ACCESS_TOKEN=${LINE_MESSAGING_CHANNEL_ACCESS_TOKEN}
+    depends_on:
+      - db
+
+  worker:
+    build: ./api
+    command: ["java","-jar","app.jar","--spring.profiles.active=worker"]
+    environment:
+      - TZ=Asia/Tokyo
+      - DATABASE_URL=jdbc:postgresql://db:5432/anshindana
+      - DATABASE_USER=app
+      - DATABASE_PASSWORD=app
+      - LINE_MESSAGING_CHANNEL_ACCESS_TOKEN=${LINE_MESSAGING_CHANNEL_ACCESS_TOKEN}
+    depends_on:
+      - db
+
+  db:
+    image: postgres:16
+    environment:
+      - POSTGRES_DB=anshindana
+      - POSTGRES_USER=app
+      - POSTGRES_PASSWORD=app
+      - TZ=Asia/Tokyo
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+volumes:
+  db-data:

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,46 @@
+## API draft (mock-first)
+
+All endpoints are prefixed with `/api`.
+
+### Auth
+
+- `POST /api/auth/line`
+  - Request: `{ "idToken": "<string>" }`
+  - Response (mock): `{ "token": "<app-jwt>", "user": { "id": 1, "displayName": "Mock User", "pictureUrl": "https://example.com/avatar.png" } }`
+
+### Scan
+
+- `POST /api/scan`
+  - Request: `{ "barcode": "4901234567890" }`
+  - Response (mock): `{ "productCandidate": { "barcode": "...", "name": "Mock Beans", "brand": "Sample", "category": "canned" }, "lastUsedExpiryTemplates": ["2025-06-01", "2025-12-01"] }`
+
+### Stock registration
+
+- `POST /api/stocks`
+  - Request: `{ "barcode": "...", "name": "string", "category": "string", "quantity": 2, "unit": "can", "expiresOn": "2025-01-01" }`
+  - Response (mock): combined stock item + lot object with generated IDs and timestamps.
+
+### List stocks
+
+- `GET /api/stocks?sort=expiresSoon`
+  - Response (mock): array of stock items including the soonest expiring lot.
+
+### Consume
+
+- `POST /api/consume`
+  - Request: `{ "stockItemId": 1, "quantity": 2 }`
+  - Response (mock): `{ "consumedLots": [...], "remainingTotal": 3 }`
+
+### Today tasks
+
+- `GET /api/tasks/today`
+  - Response (mock):
+    - `expiringSoon[]`
+    - `expired[]`
+    - `lowStock[]`
+    - `suggestedConsume[]`
+
+### Emergency plan (phase 2)
+
+- `GET /api/plan/emergency?people=4&days=3`
+  - Response (mock): per-day calorie-friendly combination suggestions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,35 @@
+## Architecture (baseline)
+
+- **Frontend (web/)**: Next.js (App Router) LIFF client. Acquires LINE `idToken`, calls backend to exchange for app JWT, surfaces four core screens (home/tasks, scan, stocks, consume). Early phases rely on mocked API responses for rapid UI iteration.
+- **Backend (api/)**: Spring Boot REST API. Handles LINE Login token verification, JWT issuance, stock/lot management with FEFO consumption, and scheduled digests under a `worker` profile.
+- **Worker (api/, worker profile)**: Scheduled job runner sharing the same codebase. Sends digest notifications and refreshes suggestion caches.
+- **Database**: PostgreSQL primary store; Redis optional for queues/caching/rate limiting.
+- **Reverse proxy (infra/nginx)**: Proxies `/api` to backend and everything else to Next.js.
+- **Local orchestration**: Docker Compose wiring services together for development.
+
+### Data model (MVP)
+
+- `users(id, line_sub, display_name, picture_url, timestamps)`
+- `products(id, barcode, name, brand, default_category, nutrition_json)`
+- `stock_items(id, user_id, product_id, total_quantity, unit, timestamps)`
+- `stock_lots(id, stock_item_id, quantity, expires_on, purchased_on, timestamps)`
+- `consumption_logs(id, user_id, stock_lot_id, delta_quantity, reason, created_at)`
+
+### Flow highlights
+
+- **Auth**: LIFF → `idToken` → `POST /api/auth/line` → verify via JWKS → upsert user → issue app JWT.
+- **Scan**: `POST /api/scan { barcode }` → product candidate & expiry templates.
+- **Register**: `POST /api/stocks` with minimal fields → stock item + lot created.
+- **Consume**: `POST /api/consume { stockItemId, quantity }` → FEFO depletion of lots.
+- **Tasks**: `GET /api/tasks/today` returning expiring/expired/low stock/suggestions buckets.
+
+### Profiles
+
+- `dev` (default): in-memory/mock services for rapid iteration.
+- `worker`: scheduled digest sender and suggestion refresher; shares domain services.
+
+### Security notes
+
+- LINE JWKS URL must be configurable and cached.
+- Application JWT secret kept in `APP_JWT_SECRET`.
+- Ensure `aud/iss/exp` validation on LINE ID tokens.

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -1,0 +1,41 @@
+## Database schema (initial proposal)
+
+### users
+- `id` (pk, bigint)
+- `line_sub` (text, unique)
+- `display_name` (text)
+- `picture_url` (text, nullable)
+- `created_at`, `updated_at`
+
+### products
+- `id` (pk, bigint)
+- `barcode` (text, unique)
+- `name` (text)
+- `brand` (text, nullable)
+- `default_category` (text, nullable)
+- `nutrition_json` (jsonb, nullable)
+- `created_at`, `updated_at`
+
+### stock_items
+- `id` (pk, bigint)
+- `user_id` (fk → users.id)
+- `product_id` (fk → products.id)
+- `total_quantity` (numeric)
+- `unit` (text)
+- `created_at`, `updated_at`
+
+### stock_lots
+- `id` (pk, bigint)
+- `stock_item_id` (fk → stock_items.id)
+- `quantity` (numeric)
+- `expires_on` (date)
+- `purchased_on` (date, nullable)
+- `created_at`, `updated_at`
+
+### consumption_logs
+- `id` (pk, bigint)
+- `user_id` (fk → users.id)
+- `stock_lot_id` (fk → stock_lots.id)
+- `delta_quantity` (numeric)
+- `reason` (enum: consume/dispose/adjust)
+- `created_at`

--- a/infra/nginx/default.conf
+++ b/infra/nginx/default.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+
+    location /api/ {
+        proxy_pass http://api:8080/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location / {
+        proxy_pass http://web:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "anshin-dana-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.4",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.10",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.4",
+    "typescript": "5.5.4"
+  }
+}

--- a/web/src/app/consume/page.tsx
+++ b/web/src/app/consume/page.tsx
@@ -1,0 +1,27 @@
+const suggestions = [
+  { id: 1, name: "冷凍唐揚げ", reason: "冷凍庫スペース確保", quantity: 2, unit: "袋" },
+  { id: 2, name: "トマトジュース", reason: "期限が近い", quantity: 1, unit: "本" }
+];
+
+export default function ConsumePage() {
+  return (
+    <main className="grid" style={{ gap: 12 }}>
+      <h1 style={{ margin: 0 }}>消費（FEFOモック）</h1>
+      <div className="grid">
+        {suggestions.map((item) => (
+          <div className="card" key={item.id}>
+            <div style={{ display: "flex", justifyContent: "space-between" }}>
+              <div style={{ fontWeight: 700 }}>{item.name}</div>
+              <span className="pill">{item.quantity}{item.unit} 提案</span>
+            </div>
+            <div style={{ fontSize: 12, color: "var(--muted)" }}>{item.reason}</div>
+            <div className="stack" style={{ marginTop: 10 }}>
+              <button>提案どおり消費</button>
+              <button className="secondary">数量を変更</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,0 +1,26 @@
+import "../styles/globals.css";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Anshin Dana",
+  description: "Household stock assistant for LINE LIFF"
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="ja">
+      <body>
+        <div className="layout">
+          <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+            <div>
+              <div style={{ fontSize: 12, color: "var(--muted)" }}>Anshin Dana</div>
+              <div style={{ fontWeight: 700, fontSize: 20 }}>在庫まるっと安心ダナ</div>
+            </div>
+            <a href="/" style={{ fontSize: 12, color: "var(--muted)" }}>HOME</a>
+          </header>
+          {children}
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,0 +1,90 @@
+const mockTasks = {
+  expiringSoon: [
+    { name: "パスタソース", expiresOn: "2024-08-03" },
+    { name: "ツナ缶", expiresOn: "2024-08-10" }
+  ],
+  expired: [{ name: "トマトジュース", expiredOn: "2024-07-01" }],
+  lowStock: [{ category: "主食", suggestion: "お米を2kg買い足し" }],
+  suggestedConsume: [
+    { name: "冷凍唐揚げ", reason: "冷凍庫スペース確保" },
+    { name: "パスタ", reason: "賞味期限が近い" }
+  ]
+};
+
+const TaskSection = ({ title, items, renderItem }: { title: string; items: any[]; renderItem: (item: any, index: number) => React.ReactNode }) => (
+  <section className="card">
+    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+      <div style={{ fontWeight: 700 }}>{title}</div>
+      <span className="pill">{items.length} 件</span>
+    </div>
+    <div className="grid">
+      {items.map(renderItem)}
+    </div>
+  </section>
+);
+
+export default function HomePage() {
+  return (
+    <main className="grid" style={{ gap: 16 }}>
+      <nav className="card">
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <a className="pill" href="/scan">スキャン登録</a>
+          <a className="pill" href="/stocks">在庫一覧</a>
+          <a className="pill" href="/consume">消費</a>
+        </div>
+        <div style={{ fontSize: 12, color: "var(--muted)", marginTop: 8 }}>LIFF起動後に idToken を取得し、バックエンドに交換する想定です。</div>
+      </nav>
+
+      <TaskSection
+        title="期限が近い"
+        items={mockTasks.expiringSoon}
+        renderItem={(item) => (
+          <div className="card" key={item.name} style={{ padding: 12 }}>
+            <div style={{ fontWeight: 600 }}>{item.name}</div>
+            <div style={{ fontSize: 12, color: "var(--muted)" }}>期限 {item.expiresOn}</div>
+            <div className="stack" style={{ marginTop: 8 }}>
+              <button>消費する</button>
+              <button className="secondary">メモ</button>
+            </div>
+          </div>
+        )}
+      />
+
+      <TaskSection
+        title="期限切れ"
+        items={mockTasks.expired}
+        renderItem={(item) => (
+          <div className="card" key={item.name} style={{ padding: 12 }}>
+            <div style={{ fontWeight: 600 }}>{item.name}</div>
+            <div style={{ fontSize: 12, color: "var(--muted)" }}>期限 {item.expiredOn}</div>
+            <button style={{ marginTop: 8 }}>点検/処分</button>
+          </div>
+        )}
+      />
+
+      <TaskSection
+        title="不足"
+        items={mockTasks.lowStock}
+        renderItem={(item, idx) => (
+          <div className="card" key={idx} style={{ padding: 12 }}>
+            <div style={{ fontWeight: 600 }}>{item.category}</div>
+            <div style={{ fontSize: 12, color: "var(--muted)" }}>{item.suggestion}</div>
+            <button style={{ marginTop: 8 }}>買い足しメモ</button>
+          </div>
+        )}
+      />
+
+      <TaskSection
+        title="今日食べる候補"
+        items={mockTasks.suggestedConsume}
+        renderItem={(item) => (
+          <div className="card" key={item.name} style={{ padding: 12 }}>
+            <div style={{ fontWeight: 600 }}>{item.name}</div>
+            <div style={{ fontSize: 12, color: "var(--muted)" }}>{item.reason}</div>
+            <button style={{ marginTop: 8 }}>消費する</button>
+          </div>
+        )}
+      />
+    </main>
+  );
+}

--- a/web/src/app/scan/page.tsx
+++ b/web/src/app/scan/page.tsx
@@ -1,0 +1,54 @@
+const mockScanResult = {
+  barcode: "4901234567890",
+  name: "Mock Beans",
+  brand: "Sample Brand",
+  category: "canned",
+  expiryTemplates: ["前回と同じ（2025-01-05）", "半年後", "1年後"]
+};
+
+export default function ScanPage() {
+  return (
+    <main className="grid" style={{ gap: 12 }}>
+      <h1 style={{ margin: 0 }}>スキャン → 登録</h1>
+      <div className="card">
+        <div style={{ fontWeight: 700, marginBottom: 8 }}>バーコードスキャン</div>
+        <div style={{ fontSize: 12, color: "var(--muted)", marginBottom: 8 }}>
+          カメラは後で `zxing-js/browser` に差し替え予定。今はモック値でUIを確認。
+        </div>
+        <div className="stack">
+          <input style={{ padding: 10, borderRadius: 10, border: "1px solid rgba(255,255,255,0.1)", background: "rgba(255,255,255,0.06)", color: "var(--text)" }} placeholder="バーコードを入力 (モック)" defaultValue={mockScanResult.barcode} />
+          <button>検索</button>
+        </div>
+      </div>
+
+      <div className="card grid">
+        <div>
+          <div style={{ fontWeight: 700 }}>候補</div>
+          <div style={{ fontSize: 12, color: "var(--muted)" }}>DBヒット時のサンプル。</div>
+        </div>
+        <div className="pill">{mockScanResult.brand}</div>
+        <div style={{ fontSize: 18, fontWeight: 700 }}>{mockScanResult.name}</div>
+        <div className="stack">
+          <span className="pill">{mockScanResult.category}</span>
+          <span className="pill">バーコード {mockScanResult.barcode}</span>
+        </div>
+      </div>
+
+      <div className="card grid">
+        <div style={{ fontWeight: 700 }}>期限テンプレート</div>
+        <div className="stack">
+          {mockScanResult.expiryTemplates.map((tpl) => (
+            <button key={tpl} className="secondary">{tpl}</button>
+          ))}
+        </div>
+        <div style={{ display: "grid", gap: 8 }}>
+          <label style={{ fontSize: 12, color: "var(--muted)" }}>数量</label>
+          <input style={{ padding: 10, borderRadius: 10, border: "1px solid rgba(255,255,255,0.1)", background: "rgba(255,255,255,0.06)", color: "var(--text)" }} defaultValue={2} />
+          <label style={{ fontSize: 12, color: "var(--muted)" }}>期限</label>
+          <input style={{ padding: 10, borderRadius: 10, border: "1px solid rgba(255,255,255,0.1)", background: "rgba(255,255,255,0.06)", color: "var(--text)" }} defaultValue="2025-01-05" />
+          <button>登録（モック）</button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/stocks/page.tsx
+++ b/web/src/app/stocks/page.tsx
@@ -1,0 +1,41 @@
+const mockStocks = [
+  {
+    id: 1,
+    name: "パスタソース",
+    totalQuantity: 5,
+    unit: "袋",
+    nextLot: { expiresOn: "2024-08-03", quantity: 2 }
+  },
+  {
+    id: 2,
+    name: "ツナ缶",
+    totalQuantity: 8,
+    unit: "缶",
+    nextLot: { expiresOn: "2024-08-10", quantity: 3 }
+  }
+];
+
+export default function StocksPage() {
+  return (
+    <main className="grid" style={{ gap: 12 }}>
+      <h1 style={{ margin: 0 }}>在庫一覧（モック）</h1>
+      <div className="grid">
+        {mockStocks.map((item) => (
+          <div className="card" key={item.id}>
+            <div style={{ display: "flex", justifyContent: "space-between" }}>
+              <div style={{ fontWeight: 700 }}>{item.name}</div>
+              <span className="pill">合計 {item.totalQuantity}{item.unit}</span>
+            </div>
+            <div style={{ marginTop: 8, fontSize: 12, color: "var(--muted)" }}>
+              最短期限: {item.nextLot.expiresOn} ({item.nextLot.quantity}{item.unit})
+            </div>
+            <div className="stack" style={{ marginTop: 10 }}>
+              <button>消費</button>
+              <button className="secondary">調整</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1,0 +1,76 @@
+:root {
+  --bg: #0f172a;
+  --card: #111827;
+  --text: #e5e7eb;
+  --accent: #22c55e;
+  --muted: #9ca3af;
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(34, 197, 94, 0.08), transparent 40%),
+    radial-gradient(circle at 80% 0%, rgba(52, 211, 153, 0.08), transparent 45%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.layout {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 24px 16px 64px;
+}
+
+.card {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.05), rgba(17, 24, 39, 0.9));
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
+}
+
+.grid {
+  display: grid;
+  gap: 12px;
+}
+
+.stack {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 12px;
+}
+
+button {
+  background: var(--accent);
+  color: #0f172a;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button.secondary {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold monorepo layout with Next.js LIFF-ready UI screens built on mock data
- add Spring Boot API skeleton with mock endpoints for auth, scan, stocks, consume, tasks, and worker cron stub
- provide docker-compose, nginx proxy, and documentation for architecture, API, and DB schema

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a3733134c8331b7db4a5687938e65)