### PR TITLE
Handle stray _stcore requests

### DIFF
--- a/infra/nginx/default.conf
+++ b/infra/nginx/default.conf
@@ -14,4 +14,12 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
+
+    # Requests to /_stcore/* are issued by Streamlit frontends (or cached service
+    # workers from previous deployments). We do not run Streamlit here, so short-
+    # circuit them to avoid noisy 404 proxy logs.
+    location /_stcore/ {
+        return 404;
+        access_log off;
+    }
 }


### PR DESCRIPTION
## Summary
- short-circuit /_stcore/* requests in nginx since we do not host Streamlit, preventing repeated proxy 404s and noisy logs

## Testing
- Not run (docker is not available in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a65054f148331949281fefe27103f)